### PR TITLE
KDE KF6 update

### DIFF
--- a/org.kde.kfourinline.json
+++ b/org.kde.kfourinline.json
@@ -18,8 +18,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/libkdegames-23.08.5.tar.xz",
-                    "sha256": "0ac583f4327d6003782054a9ee3d51c922bcdf04577a3f7f12b3840cabf2efed",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/libkdegames-24.02.0.tar.xz",
+                    "sha256": "3d113422dc654348b2025de5fe1de256d06a3c55be9c7b104253e25595b2e2b1",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kfourinline-23.08.5.tar.xz",
-                    "sha256": "6d08110ab4af50f96bf996f5baf7f863736d0696024bfe27a0ed4a532fcbd7ba",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kfourinline-24.02.0.tar.xz",
+                    "sha256": "9623f8d1d3e982806be6e167cc7b020fb1438c728e4de98840d57a947aeda373",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,

--- a/org.kde.kfourinline.json
+++ b/org.kde.kfourinline.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.kfourinline",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-23.08",
+    "runtime-version": "6.6",
     "sdk": "org.kde.Sdk",
     "command": "kfourinline",
     "rename-icon": "kfourinline",


### PR DESCRIPTION
Update libkdegames-23.08.5.tar.xz to 24.02.0
Update kfourinline-23.08.5.tar.xz to 24.02.0